### PR TITLE
chore: remove missing slotmap repo

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -22,4 +22,4 @@
 	url = https://github.com/N64Recomp/N64Recomp
 [submodule "lib/slot_map"]
 	path = lib/slot_map
-	url = https://github.com/SergeyMakeev/slot_map
+	url = https://github.com/SergeyMakeev/SlotMap


### PR DESCRIPTION
This repository was moved and should probably be fixed. 